### PR TITLE
fix(tools): eliminate double-send bug; remove dead validation code

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -215,14 +215,6 @@ function messageTextLength(msg: UIMessage): number {
   return total;
 }
 
-function estimateInputChars(messages: UIMessage[]): number {
-  let total = 0;
-  for (const msg of messages) {
-    total += messageTextLength(msg);
-  }
-  return total;
-}
-
 function validateMessages(messages: UIMessage[]): string | null {
   for (let i = 0; i < messages.length; i++) {
     if (messageTextLength(messages[i]) > MAX_MESSAGE_CHARS) {
@@ -290,11 +282,6 @@ export async function POST(request: Request) {
   const msgError = validateMessages(messages);
   if (msgError) {
     return new Response(msgError, { status: 400 });
-  }
-
-  const totalInputChars = estimateInputChars(messages);
-  if (totalInputChars > MAX_MESSAGES * MAX_MESSAGE_CHARS) {
-    return new Response("Total message content exceeds maximum allowed size", { status: 413 });
   }
 
   const validMode = mode === "tools" ? "tools" : "chat";

--- a/app/components/ChatHome.tsx
+++ b/app/components/ChatHome.tsx
@@ -268,18 +268,10 @@ export default function ChatHome({ mode = "chat" }: ChatHomeProps) {
     return () => clearTimeout(timer);
   }, [isLoadingChat, chat]);
 
-  // Quick action handler — routes through the composer setText + Send click pipeline,
-  // the same code path as manual user submission. Using runtime.thread.append() directly
-  // causes the stream to arrive but never render (AI SDK 5 `content` format vs SDK 6
-  // `parts` format mismatch in the useAISDKRuntime bridge).
   const handleQuickAction = useCallback(
     (prompt: string) => {
       runtime.thread.composer.setText(prompt);
-      // Defer one tick so React processes setText before the click fires
-      setTimeout(() => {
-        const btn = document.querySelector<HTMLButtonElement>('[aria-label="Send message"]');
-        btn?.click();
-      }, 0);
+      runtime.thread.composer.send();
     },
     [runtime],
   );

--- a/app/components/QuickActions.tsx
+++ b/app/components/QuickActions.tsx
@@ -38,7 +38,7 @@ const CHAT_ACTIONS: Action[] = [
   },
 ];
 
-const TOOLS_ACTIONS_ROW1: Action[] = [
+const TOOLS_ACTIONS: Action[] = [
   {
     label: "Cover Letter",
     prompt: "Generate a tailored cover letter. I'll paste the job description next.",
@@ -58,9 +58,6 @@ const TOOLS_ACTIONS_ROW1: Action[] = [
     prompt:
       "Generate a cold email introduction. I'll provide the recipient's name, company, and context.",
   },
-];
-
-const TOOLS_ACTIONS_ROW2: Action[] = [
   {
     label: "Thank You Note",
     prompt:
@@ -93,7 +90,7 @@ const ctaChipClass =
  * Chat mode appends a BookInterviewLink CTA chip at the end.
  */
 export default function QuickActions({ mode, onAction, onPrefill }: QuickActionsProps) {
-  const actions = mode === "chat" ? CHAT_ACTIONS : [...TOOLS_ACTIONS_ROW1, ...TOOLS_ACTIONS_ROW2];
+  const actions = mode === "chat" ? CHAT_ACTIONS : TOOLS_ACTIONS;
 
   return (
     <div className="flex flex-wrap gap-1.5">

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -20,7 +20,7 @@ import { SAMPLE_RESUME_MD, SAMPLE_RESUME_CLEAN } from "./fixtures/sample-data.js
 
 // ─── Markdown Comment Stripping ─────────────────────────────────────────────
 // The export pipeline strips HTML comment headers before converting.
-// This logic is duplicated in export-resume.ts and page.tsx, so test both patterns.
+// Logic is centralized in lib/markdown.ts; used by export-resume.ts, page.tsx, and release-check.ts.
 
 describe("HTML comment stripping", () => {
   it("strips generation metadata comments", () => {


### PR DESCRIPTION
## Root cause

`handleQuickAction` called `btn.click()` on a `type="submit"` button inside a `<form>`. This fired **two** handlers simultaneously — `ComposerPrimitive.Send`'s onClick and the form's `onSubmit` — resulting in two concurrent `AbstractChat.makeRequest()` calls. The second call set `this.activeResponse = undefined`; the first's `finally` block then read `undefined.state` → TypeError. This crashed the chat state machine and left the `/tools` page non-functional for all subsequent requests (both chips and direct text).

BUG-02 (60s timeout not triggering) was a secondary effect: the TypeError reset `chat.status` to `"ready"` immediately, making `isLoadingChat` false before the timer fired.

## Fix

- `handleQuickAction`: replace `setText + setTimeout(btn.click())` with `setText + composer.send()` — submits once through the correct pipeline, no DOM hacking

## Cleanup

- `QuickActions.tsx`: merge `TOOLS_ACTIONS_ROW1` + `TOOLS_ACTIONS_ROW2` into `TOOLS_ACTIONS` (were always spread-concatenated, never used separately)
- `route.ts`: remove `estimateInputChars()` and its aggregate guard — unreachable after per-message validation (50 × 4,000 chars ≤ the 200,000 boundary it checked)
- `export.test.ts`: fix stale comment claiming logic was "duplicated" (it's centralized in `lib/markdown.ts`)

## Test plan

- [ ] `/tools` → click any chip → one API call, response renders, no TypeError
- [ ] `/tools` → type directly, press Enter → response renders
- [ ] Throttle network → "Response timed out" banner appears after 60s
- [ ] `/` → click any chip → still works (regression)
- [ ] Multi-turn tailored resume on `/` → second resume still renders (PR #30 regression)
- [ ] `npm test` → 493 pass, 0 TypeScript errors ✅ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)