### PR TITLE
feat: Lighthouse fixes + P1 multi-turn tailored resume blank bubble

### DIFF
--- a/.claude/commands/uat.md
+++ b/.claude/commands/uat.md
@@ -53,6 +53,7 @@ Use the Playwright MCP browser tool to verify each item:
 
 - [ ] `x-frame-options: DENY`
 - [ ] `strict-transport-security` present
+- [ ] `cross-origin-opener-policy: same-origin` present
 - [ ] `x-robots-tag: noindex` is **absent** on production (present on preview — expected)
 - [ ] CORS: `access-control-allow-origin` is `https://paulprae.com` (not `*`)
 
@@ -61,6 +62,12 @@ Use the Playwright MCP browser tool to verify each item:
 - [ ] `POST /api/chat` with empty body → 400
 - [ ] `POST /api/chat` with `{"messages":[]}` → 400
 - [ ] `GET /api/cron` without auth → 401
+
+### Multi-turn tailored resume (regression: BUG-NEW-01)
+
+- [ ] Send "Tailor my resume for a Principal AI Engineer role at a healthcare SaaS company" → resume renders (not blank)
+- [ ] In the **same session**, send "Now tailor it for a Senior ML Engineer at a fintech startup building fraud detection" → second resume renders (not blank)
+- [ ] Blank bubble on Turn 2 = `tool-input-error` regression; check Vercel logs for `[tool:generate_tailored_resume]` error
 
 ## Cache health (check after any chat interaction)
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -65,7 +65,7 @@ export const generateTailoredResumeInputSchema = z.object({
     .describe("The job description or role requirements to tailor the resume for"),
   emphasisAreas: z
     .array(
-      z
+      z.coerce
         .string()
         .max(
           CHAT_REQUEST_LIMITS.maxEmphasisChars,
@@ -76,7 +76,7 @@ export const generateTailoredResumeInputSchema = z.object({
       CHAT_REQUEST_LIMITS.maxEmphasisItems,
       `Maximum ${CHAT_REQUEST_LIMITS.maxEmphasisItems} emphasis areas`,
     )
-    .optional()
+    .nullish()
     .describe("Specific areas to emphasize (e.g., 'AI/ML', 'healthcare', 'leadership')"),
 });
 
@@ -324,8 +324,12 @@ export async function POST(request: Request) {
             inputSchema: generateTailoredResumeInputSchema,
             execute: async ({ jobDescription, emphasisAreas }) => {
               try {
+                // Truncate as a safety net in case the model produces verbose content
+                // that approaches schema limits. null → undefined for buildTailoredResumePrompt.
+                const safeJD = jobDescription.slice(0, CHAT_REQUEST_LIMITS.maxJobDescriptionChars);
+                const safeEmphasis = emphasisAreas ?? undefined;
                 const resumeSystemPrompt = getSystemPrompt("resume-generator");
-                const userPrompt = buildTailoredResumePrompt(jobDescription, emphasisAreas, true);
+                const userPrompt = buildTailoredResumePrompt(safeJD, safeEmphasis, true);
 
                 const { text, finishReason } = await generateText({
                   model: getModel(CHAT_MODEL_ID),

--- a/app/components/ChatHome.tsx
+++ b/app/components/ChatHome.tsx
@@ -330,7 +330,7 @@ export default function ChatHome({ mode = "chat" }: ChatHomeProps) {
                           <p className="mt-2 sm:mt-3 hidden sm:block max-w-lg text-sm leading-relaxed text-slate-500 dark:text-slate-400">
                             {HERO_DESCRIPTION}
                           </p>
-                          <p className="mt-2 max-w-lg text-xs text-slate-400 dark:text-slate-500">
+                          <p className="mt-2 max-w-lg text-xs text-slate-600 dark:text-slate-400">
                             Ask about Paul&apos;s experience, download his resume, or request a
                             tailored resume for your open role.
                           </p>
@@ -433,7 +433,7 @@ export default function ChatHome({ mode = "chat" }: ChatHomeProps) {
         </main>
 
         <footer className="shrink-0 py-1.5 text-center">
-          <p className="text-xs text-slate-400 dark:text-slate-500">
+          <p className="text-xs text-slate-600 dark:text-slate-400">
             {SITE_DOMAIN} &mdash; Built with Next.js, Claude AI, and Tailwind CSS &mdash;{" "}
             <a href={GITHUB_URL} {...externalLinkProps(GITHUB_URL)} className={FOOTER_LINK_CLASS}>
               view source

--- a/docs/uat-checklist.md
+++ b/docs/uat-checklist.md
@@ -10,7 +10,7 @@ Run this checklist after every major deployment. Automated tests (unit, E2E, CI 
 
 ```bash
 npm run check:quick   # data files, resume quality, public download sync
-npx vitest run        # unit + component tests (480+ tests)
+npx vitest run        # unit + component tests (493+ tests)
 npx tsc --noEmit      # TypeScript compilation
 npx eslint .          # linting
 ```
@@ -39,6 +39,10 @@ The primary value proposition. Test this first on every deployment.
 - [ ] Tool-calling triggers (may take 30-60s) and returns a formatted tailored resume
 - [ ] Tailored resume references content from the actual career data
 - [ ] Click "Download resume" chip — returns links to PDF, DOCX, Markdown, and web resume
+- [ ] **Multi-turn tailored resume (regression test for BUG-NEW-01):**
+  - Turn 1: click "Tailored resume", paste "Principal AI Engineer at a healthcare SaaS company", send → resume renders ✅
+  - Turn 2 (same session): send "Now tailor it for a Senior ML Engineer at a fintech startup building fraud detection" → resume renders, NOT blank ✅
+  - A blank assistant bubble on Turn 2 means the `emphasisAreas` Zod schema is rejecting the tool input
 
 ### Quick Action Chips
 
@@ -123,6 +127,7 @@ Test before every production push — these are trust-critical.
 ### Security Headers
 
 - [ ] View response headers (DevTools → Network): CSP, HSTS, X-Frame-Options, X-Content-Type-Options present
+- [ ] `cross-origin-opener-policy: same-origin` present (added in PR #33)
 
 ## 4. Book Interview CTA
 
@@ -166,6 +171,8 @@ The primary conversion action — verify on every deployment.
 - [ ] Chat composer is visible at bottom with placeholder text
 - [ ] Dark mode: toggle system theme, verify no color clashes or unreadable text
 - [ ] Skip-to-content link appears on Tab press (no visible flash on page load or client-side navigation)
+- [ ] Hero description text is legible (dark slate, sufficient contrast — not washed-out light gray)
+- [ ] Footer text ("paulprae.com — Built with…") is legible with good contrast
 
 ### Accessibility
 
@@ -211,7 +218,7 @@ Test on a real phone or browser DevTools (375px width):
 
 - [ ] First page load under 3 seconds on broadband
 - [ ] Chat first response (TTFT) under 5 seconds
-- [ ] Lighthouse score: Performance ≥ 90, Accessibility ≥ 90, SEO ≥ 90
+- [ ] Lighthouse score: Performance ≥ 90, Accessibility = 100, Best Practices ≥ 96, SEO = 100
 - [ ] Check Vercel Dashboard > Functions — `/api/chat` executions appear
 - [ ] Check Anthropic Console > Usage — requests appear, within spend limits
 - [ ] Check Upstash Console — rate limiting counters active under `paulprae:chat` prefix

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -110,9 +110,9 @@ export const MAX_MESSAGE_CHARS = 4_000;
 export const CHAT_REQUEST_LIMITS = {
   maxMessages: 50,
   maxBodyBytes: 256_000,
-  maxJobDescriptionChars: 10_000,
+  maxJobDescriptionChars: 50_000,
   maxEmphasisItems: 10,
-  maxEmphasisChars: 200,
+  maxEmphasisChars: 500,
 } as const;
 
 // ─── Rate Limiting ──────────────────────────────────────────────────────────

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,18 @@ const nextConfig: NextConfig = {
       "./data/sources/knowledge/**/*.json",
     ],
   },
+
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          // Prevent cross-origin popups from retaining opener access (fixes COOP inspector issue).
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,12 @@
     "remark-gfm": "^4.0.1",
     "zod": "^4.3.6"
   },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "lint-staged": {
     "**/*.{ts,tsx,js,mjs,json,css,md}": "prettier --write"
   },

--- a/tests/tool-calling.test.ts
+++ b/tests/tool-calling.test.ts
@@ -60,7 +60,7 @@ describe("generate_tailored_resume schema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects emphasis area exceeding 200 characters", () => {
+  it("rejects emphasis area exceeding max character limit", () => {
     const result = generateTailoredResumeInputSchema.safeParse({
       jobDescription: "Valid JD.",
       emphasisAreas: ["x".repeat(CHAT_REQUEST_LIMITS.maxEmphasisChars + 1)],


### PR DESCRIPTION
## Summary

### P1 Bug Fix — Multi-turn tailored resume blank bubble (BUG-NEW-01)

**Root cause**: The `generate_tailored_resume` Zod schema rejects `emphasisAreas` on the second tool invocation, producing a `tool-input-error` SSE event. After `tool-input-error`, the AI SDK does NOT invoke the model again — the stream ends immediately with an empty assistant message (blank bubble).

Two failure modes identified:
1. **`null` rejection**: Model sends `"emphasisAreas": null` (explicit JSON null). `.optional()` only accepts `undefined`; `.nullish()` accepts both.
2. **Length overflow**: Model generates verbose emphasis areas >200 chars on the second call with richer conversation context (the prior tailored resume is visible in context, causing more descriptive output).

**Key insight from AI SDK source**: `maxOutputTokens: 2048` limits the model's tool call JSON to ~8K chars — meaning `jobDescription` (capped at 10K) could *never* be exceeded. The actual failure is always in `emphasisAreas`.

**Changes** (`lib/constants.ts`, `app/api/chat/route.ts`, `tests/tool-calling.test.ts`):
- `maxEmphasisChars` 200→500 (accommodates verbose LLM output)
- `maxJobDescriptionChars` 10K→50K (defensive; theoretically unreachable)
- `emphasisAreas` schema: `z.coerce.string()` (handles non-string items), `.nullish()` (accepts null)
- `execute()`: add `safeJD` truncation + `null→undefined` coercion as belt-and-suspenders

---

### Lighthouse Fixes

- **Accessibility 96→100**: Fix `text-slate-400` color contrast failures — hero description + footer paragraph now use `text-slate-600` (contrast 7.0:1, up from 2.63:1). The inherited "view source" link is fixed as a side effect.
- **Performance (legacy JS ~14KB)**: Add `browserslist` to `package.json` targeting last 2 versions of Chrome/Firefox/Safari/Edge. Eliminates polyfills for `Array.at/flat/flatMap`, `Object.fromEntries`, `Object.hasOwn`, `String.trimEnd/trimStart`.
- **Best Practices**: Add `Cross-Origin-Opener-Policy: same-origin` response header.

---

## Test plan

- [ ] `npm test` — 493 tests pass ✅
- [ ] `npx tsc --noEmit` — no TypeScript errors ✅
- [ ] Multi-turn resume: Turn 1 → "Tailor for Principal AI Engineer at healthcare SaaS" → renders ✅; Turn 2 → "Now tailor for Senior ML Engineer at fintech startup" → renders (not blank) ✅
- [ ] After deploy: run Lighthouse, verify Accessibility = 100
- [ ] Verify `Cross-Origin-Opener-Policy: same-origin` header present

🤖 Generated with [Claude Code](https://claude.com/claude-code)