### PR TITLE
docs: add Autonomize AI team intro deliverable

### DIFF
--- a/data/generated/deliverables/2026-04-08-autonomize-team-intro.md
+++ b/data/generated/deliverables/2026-04-08-autonomize-team-intro.md
@@ -1,0 +1,54 @@
+<!-- Finalized deliverable — approved 2026-04-08 -->
+<!-- Purpose: Team + LinkedIn introduction for Paul Prae joining Autonomize AI -->
+<!-- Audience: Autonomize internal all-hands (via Ujjwal R., VP Solutions & Delivery Engineering) + later LinkedIn company post -->
+<!-- Role: Solutions Architect — Solutions & Delivery Engineering -->
+<!-- Start date: 2026-04-13 -->
+<!-- Source of truth: data/generated/career-data.json -->
+
+# Autonomize AI — Team Introduction
+
+## Version 1 — Internal intro (for Ujjwal to share company-wide)
+
+Team — please join me in welcoming **Paul Prae**, who joins us on **April 13** as a **Solutions Architect** on Solutions & Delivery Engineering.
+
+Paul is an AI and data engineering leader with 13+ years building production systems across healthcare, life sciences, and financial services. Most recently he served as Chief AI Architect at Booz Allen Hamilton, leading AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments. Before that he was an Enterprise AI/ML Solutions Architect at AWS, where he guided Fortune 500 accounts through cloud-native AI architectures, and he got his start in healthcare and life sciences analytics consulting at Slalom, delivering a statewide behavioral health forecasting system in Georgia.
+
+He's a four-time AWS-certified architect (including ML Engineer and ML Specialty), a published neuroinformatics researcher, and founder of Modular Earth, a non-profit building open-source AI agents. He's genuinely excited to help our customers across healthcare and life sciences ship AI that moves the needle on care and research.
+
+You can learn more — or chat with his AI assistant — at **paulprae.com**.
+
+Welcome, Paul!
+
+---
+
+## Version 2 — LinkedIn company post (for the social team to spin)
+
+We're thrilled to welcome **Paul Prae** to Autonomize AI as a **Solutions Architect** on our Solutions & Delivery Engineering team 🎉
+
+Paul brings 13+ years of AI and data engineering leadership across healthcare, life sciences, and financial services — exactly the blend of enterprise delivery muscle and applied AI depth our customers need.
+
+A few highlights from his journey:
+
+🏥 **Healthcare & life sciences AI leadership** — Former Chief AI Architect at Booz Allen Hamilton, where he led AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments, harnessing clinical, behavioral, and genomic data for population health and predictive medicine.
+
+☁️ **Enterprise cloud architecture** — Former Enterprise AI/ML Solutions Architect at AWS, partnering with Fortune 500 accounts on cloud-native AI. Four-time AWS certified, including ML Engineer and ML Specialty.
+
+🔬 **Research credibility** — Co-authored peer-reviewed work in *Frontiers in Neuroinformatics* on federated analysis and differential privacy for protected health data.
+
+🌱 **Mission-driven** — Founder of Modular Earth, a non-profit building open-source AI agents to expand access to opportunity.
+
+Paul joins us to help design and deploy scalable, secure AI solutions for customers across healthcare and life sciences — from clinical review and risk adjustment to research workflows and knowledge automation. His combination of client-facing solutioning, regulatory fluency, and hands-on AI engineering is going to be a force multiplier for our customers.
+
+Welcome to the Autonomize family, Paul! 👋
+
+Learn more at **paulprae.com**.
+
+---
+
+## Notes on honesty & fact-checking
+
+- Every claim is sourced from `data/generated/career-data.json` — no invented metrics, no embellished titles.
+- **HL7 / FHIR / EDI 837/835** are JD requirements but are not explicitly listed on Paul's resume, so they are intentionally not claimed here. HIPAA and FedRAMP experience carry the regulatory weight.
+- Per Paul's instruction, Arine and Avahi are omitted; the current role is referenced only obliquely ("13+ years…").
+- "Customers across healthcare and life sciences" replaces earlier payer-centric framing per team feedback that the public website over-emphasizes payers.
+- Photo handled separately by Paul.

--- a/data/generated/deliverables/2026-04-08-autonomize-team-intro.md
+++ b/data/generated/deliverables/2026-04-08-autonomize-team-intro.md
@@ -11,7 +11,7 @@
 
 Team — please join me in welcoming **Paul Prae**, who joins us on **April 13** as a **Solutions Architect** on Solutions & Delivery Engineering.
 
-Paul is an AI and data engineering leader with 13+ years building production systems across healthcare, life sciences, and financial services. Most recently he served as Chief AI Architect at Booz Allen Hamilton, leading AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments. Before that he was an Enterprise AI/ML Solutions Architect at AWS, where he guided Fortune 500 accounts through cloud-native AI architectures, and he got his start in healthcare and life sciences analytics consulting at Slalom, delivering a statewide behavioral health forecasting system in Georgia.
+Paul is an AI and data engineering leader with 13+ years building production systems across healthcare, life sciences, and financial services. His background includes serving as Chief AI Architect at Booz Allen Hamilton, where he led AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments; as an Enterprise AI/ML Solutions Architect at AWS, guiding Fortune 500 accounts through cloud-native AI architectures; and as an analytics consultant at Slalom, delivering a statewide behavioral health forecasting system in Georgia.
 
 He's a four-time AWS-certified architect (including ML Engineer and ML Specialty), a published neuroinformatics researcher, and founder of Modular Earth, a non-profit building open-source AI agents. He's genuinely excited to help our customers across healthcare and life sciences ship AI that moves the needle on care and research.
 
@@ -29,9 +29,9 @@ Paul brings 13+ years of AI and data engineering leadership across healthcare, l
 
 A few highlights from his journey:
 
-🏥 **Healthcare & life sciences AI leadership** — Former Chief AI Architect at Booz Allen Hamilton, where he led AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments, harnessing clinical, behavioral, and genomic data for population health and predictive medicine.
+🏥 **Healthcare & life sciences AI leadership** — Chief AI Architect experience at Booz Allen Hamilton, leading AI and analytics solution development for healthcare and life science clients in FedRAMP- and HIPAA-compliant environments, harnessing clinical, behavioral, and genomic data for population health and predictive medicine.
 
-☁️ **Enterprise cloud architecture** — Former Enterprise AI/ML Solutions Architect at AWS, partnering with Fortune 500 accounts on cloud-native AI. Four-time AWS certified, including ML Engineer and ML Specialty.
+☁️ **Enterprise cloud architecture** — Enterprise AI/ML Solutions Architect experience at AWS, partnering with Fortune 500 accounts on cloud-native AI. Four-time AWS certified, including ML Engineer and ML Specialty.
 
 🔬 **Research credibility** — Co-authored peer-reviewed work in *Frontiers in Neuroinformatics* on federated analysis and differential privacy for protected health data.
 
@@ -49,6 +49,6 @@ Learn more at **paulprae.com**.
 
 - Every claim is sourced from `data/generated/career-data.json` — no invented metrics, no embellished titles.
 - **HL7 / FHIR / EDI 837/835** are JD requirements but are not explicitly listed on Paul's resume, so they are intentionally not claimed here. HIPAA and FedRAMP experience carry the regulatory weight.
-- Per Paul's instruction, Arine and Avahi are omitted; the current role is referenced only obliquely ("13+ years…").
+- Per Paul's instruction, his two most recent roles are omitted. Recency phrasing ("most recently," "former") has been removed so the intro lists prior experience without implying it was his last job.
 - "Customers across healthcare and life sciences" replaces earlier payer-centric framing per team feedback that the public website over-emphasizes payers.
 - Photo handled separately by Paul.


### PR DESCRIPTION
## Summary
- Adds finalized team + LinkedIn introduction for joining Autonomize AI as Solutions Architect
- Saved under `data/generated/deliverables/` as an example of approved generated output

## Test plan
- [x] Content grounded in `data/generated/career-data.json`
- [x] Framing updated to "healthcare and life sciences" (not payer-centric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)